### PR TITLE
Prevent new account creation for anonymous users

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -112,6 +112,7 @@ $wgDiff3 = "/usr/bin/diff3";
 
 # The following permissions were set based on your choice in the installer
 $wgGroupPermissions['*']['edit'] = false;
+$wgGroupPermissions['*']['createaccount'] = false;
 
 ## Default skin: you can change the default skin. Use the internal symbolic
 ## names, ie 'vector', 'monobook':


### PR DESCRIPTION
Uživatel s sysop oprávněním bude stále moci editovat.


Ve chvíli, kdy se za den vytvoří 10+ spamujících účtů (a zhruba 1 validní účet za rok), bude fajn zavřít dveře do kurníku.